### PR TITLE
Fix 2x markers

### DIFF
--- a/dist/leaflet.awesome-markers.css
+++ b/dist/leaflet.awesome-markers.css
@@ -27,7 +27,7 @@ Version: 1.0
 (-webkit-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5),(min-resolution: 1.5dppx) {
  .awesome-marker {
   background-image: url('images/markers-soft@2x.png');
-  background-size: 720px 46px;
+  background-size: 720px 92px;
  }
  .awesome-marker-shadow {
   background-image: url('images/markers-shadow@2x.png');


### PR DESCRIPTION
CSS was not updated so both regular and square markers appeared as one marker, squashed to fit.

<img width="85" alt="zrzut ekranu 2017-01-21 o 02 32 37" src="https://cloud.githubusercontent.com/assets/1978721/22170752/761089c8-df82-11e6-9f9b-11c6e136e73c.png">
